### PR TITLE
filter out only nfts in token_balances request by the logic that non …

### DIFF
--- a/internal/postgres/domains/storage.go
+++ b/internal/postgres/domains/storage.go
@@ -38,6 +38,7 @@ func (storage *Storage) TokenBalances(network types.Network, contract, address s
 	if contract != "" {
 		query.Where("contract = ?", contract)
 	}
+	query.Where("token_id != ?", 0)
 
 	switch sort {
 	case "token_id":


### PR DESCRIPTION
…nfts have token_id of 0 in the db